### PR TITLE
manual_build: build Godwoken with `gw-config/no-builtin` feature

### DIFF
--- a/docs/manual-build.md
+++ b/docs/manual-build.md
@@ -30,7 +30,7 @@ Let's start with an example to demonstrate how Godwoken-Kicker supports manual-b
   ```shell
   MANUAL_BUILD_GODWOKEN=true \
   GODWOKEN_GIT_URL=ssh://git@github.com/godwokenrises/godwoken \
-  GODWOKEN_GIT_CHECKOUT=compatibility-breaking-changes \
+  GODWOKEN_GIT_CHECKOUT=develop \
   ./kicker manual-build
   ```
 

--- a/kicker
+++ b/kicker
@@ -456,14 +456,20 @@ function manual_build() {
         prepare_repo godwoken "$GODWOKEN_GIT_URL" "$GODWOKEN_GIT_CHECKOUT"
 
         # Cargo fetch Rust dependencies (in order to access network via
-        # host network). The docker image must have installed cargo and molecule
+        # host network).
+        # Note:
+        # 1. The docker image must have installed cargo and molecule
+        # 2. The builtin consensus config and binaries are not required on a 
+        #    Godwoken devnet, so `--features gw-config/no-builtin` is appended
+        #    to `cargo build` arguments.
         erun docker run \
             --rm \
             --env CARGO_HOME=/app/.cargo \
             --volume $srcdir:/app \
             --volume $WORKSPACE/packages/.rustup:/root/.rustup \
             --workdir /app \
-            retricsu/godwoken-manual-build:ckb2021 cargo build --locked --release
+            retricsu/godwoken-manual-build:ckb2021 \
+            cargo build --locked --release --features gw-config/no-builtin
 
         # Copy the built artifacts to `docker/manual-artifacts/`
         #


### PR DESCRIPTION
The builtin consensus config and binaries are not required on a  Godwoken devnet, so `--features gw-config/no-builtin` is appended to `cargo build` arguments.