### PR TITLE
fix(kicker init): remove target/release/examples 

### DIFF
--- a/kicker
+++ b/kicker
@@ -534,6 +534,11 @@ function manual_build() {
         erun mkdir -p $dstdir
         erun cp $srcdir/target/release/godwoken $dstdir
         erun cp $srcdir/target/release/gw-tools $dstdir
+
+        # Remove target/release/examples to avoid `out of disk` issue in CI
+        du -hd1 $srcdir/target
+        rm -rf $srcdir/target/release/examples
+        du -hd1 $srcdir/target
     else
         info "skip building Godwoken"
     fi


### PR DESCRIPTION
to avoid `out of disk` issue in CI

## Known failed CIs
- [godwoken-tests / test-on-devnet-v1](https://github.com/godwokenrises/godwoken/actions/runs/6515541217/job/17698087986#step:1:56)
You are running out of disk space. The runner will stop working when the machine runs out of disk space. Free space left: 78 MB
> https://github.com/godwokenrises/godwoken/actions/runs/6515541217?pr=1097

- [web3-unit-tests](https://github.com/godwokenrises/godwoken/actions/runs/6515541179/job/17698087879#step:1:28)
You are running out of disk space. The runner will stop working when the machine runs out of disk space. Free space left: 51 MB
> https://github.com/godwokenrises/godwoken/actions/runs/6515541179?pr=1097

